### PR TITLE
Prevent Undefined index: tab PHP notice

### DIFF
--- a/includes/class-wc-enhanced-ecommerce-google-analytics-integration.php
+++ b/includes/class-wc-enhanced-ecommerce-google-analytics-integration.php
@@ -1120,8 +1120,7 @@ class WC_Enhanced_Ecommerce_Google_Analytics extends WC_Integration {
     function admin_check_UA_enabled() {
     	
     	$t_tab_name = '';
-    	if(isset($_GET['tab'])) {
-    		$t_tab_name = $_GET['tab'];
+    	if(isset($_GET['tab'])) $t_tab_name = $_GET['tab'];
         	
        if($t_tab_name=='integration'){
 

--- a/includes/class-wc-enhanced-ecommerce-google-analytics-integration.php
+++ b/includes/class-wc-enhanced-ecommerce-google-analytics-integration.php
@@ -1118,7 +1118,11 @@ class WC_Enhanced_Ecommerce_Google_Analytics extends WC_Integration {
      * @access public
      */
     function admin_check_UA_enabled() {
-        $t_tab_name = $_GET['tab'];
+    	
+    	$t_tab_name = '';
+    	if(isset($_GET['tab'])) {
+    		$t_tab_name = $_GET['tab'];
+        	
        if($t_tab_name=='integration'){
 
         echo '<script>


### PR DESCRIPTION
Using Query Monitor plugin you can see that there is PHP notice undefined index: tab. You can fix this using isset(). There might be tidier way to do this in this.

Reason of empty sting variable to prevent errors of undefined variable. Any ideas to tidy this ?
