### PR TITLE
Fix incorrect property in homepage json object

### DIFF
--- a/includes/class-wc-enhanced-ecommerce-google-analytics-integration.php
+++ b/includes/class-wc-enhanced-ecommerce-google-analytics-integration.php
@@ -560,7 +560,7 @@ class WC_Enhanced_Ecommerce_Google_Analytics extends WC_Integration {
                         "tvc_id" => esc_html($product->id),
                         "tvc_i" => esc_html($product->get_sku() ? $product->get_sku() : $product->id),
                         "tvc_n" => esc_html($product->get_title()),
-                        "tvc_n" => esc_html($product->get_price()),
+                        "tvc_p" => esc_html($product->get_price()),
                         "tvc_c" => esc_html($categories),
                         "tvc_po" => ++$_SESSION['t_fpcnt'],
                         "ATC-link"=>$product->add_to_cart_url()


### PR DESCRIPTION
Changed duplicate property "tvc_n" to "tvc_p" for product price in $homepage_json_fp
